### PR TITLE
[parse-cli] refactor code from login.go to create a 'configure token' command

### DIFF
--- a/configure_cmd.go
+++ b/configure_cmd.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"fmt"
+
+	"github.com/facebookgo/stackerr"
+	"github.com/spf13/cobra"
+)
+
+type configureCmd struct {
+	login login
+}
+
+func (c *configureCmd) accessToken(e *env) error {
+	fmt.Fprintf(e.Out,
+		`Please enter the email id you used to register with Parse
+and an access token if you already generated it.
+If you do not have an access token or would like to generate a new one,
+please type: "y" to open the browser or "n" to continue: `,
+	)
+
+	c.login.helpCreateToken(e)
+
+	var credentials credentials
+	fmt.Fprintf(e.Out, "Email: ")
+	fmt.Fscanf(e.In, "%s\n", &credentials.email)
+	fmt.Fprintf(e.Out, "Account Key: ")
+	fmt.Fscanf(e.In, "%s\n", &credentials.token)
+
+	_, err := (&apps{login: login{credentials: credentials}}).restFetchApps(e)
+	if err != nil {
+		if err == errAuth {
+			fmt.Fprintf(e.Err,
+				`Sorry, we do not have a user with this email and access token.
+Please follow instructions at %s to generate a new access token.
+`,
+				keysURL,
+			)
+		} else {
+			fmt.Fprintf(e.Err, "Unable to validate token with error:\n%s\n", err)
+		}
+		return stackerr.New("Could not store credentials. Please try again.")
+	}
+
+	err = c.login.storeCredentials(e, &credentials)
+	if err == nil {
+		fmt.Fprintln(e.Out, "Successfully stored credentials.")
+	}
+	return stackerr.Wrap(err)
+}
+
+func newConfigureCmd(e *env) *cobra.Command {
+	var c configureCmd
+
+	cmd := &cobra.Command{
+		Use:   "configure",
+		Short: "Configure various Parse settings.",
+		Long:  "Configure various Parse settings like access tokens, project type, and more.",
+		Run: func(c *cobra.Command, args []string) {
+			c.Help()
+		},
+	}
+	cmd.AddCommand(&cobra.Command{
+		Use:   "token",
+		Short: "Store Parse access token on machine",
+		Long:  "Stores Parse access token in ~/.parse/netrc.",
+		Run:   runNoArgs(e, c.accessToken),
+	})
+	return cmd
+}

--- a/configure_cmd_test.go
+++ b/configure_cmd_test.go
@@ -1,0 +1,36 @@
+package main
+
+import (
+	"io/ioutil"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/facebookgo/ensure"
+)
+
+func TestConfigureAcessToken(t *testing.T) {
+	t.Parallel()
+
+	h, _ := newAppHarness(t)
+	defer h.Stop()
+
+	c := configureCmd{login: login{tokenReader: strings.NewReader("")}}
+	h.env.In = ioutil.NopCloser(strings.NewReader("n\nemail\ntoken\n"))
+	ensure.Nil(t, c.accessToken(h.env))
+	ensure.DeepEqual(t,
+		h.Out.String(),
+		`Please enter the email id you used to register with Parse
+and an access token if you already generated it.
+If you do not have an access token or would like to generate a new one,
+please type: "y" to open the browser or "n" to continue: Email: Account Key: Successfully stored credentials.
+`)
+
+	h.env.In = ioutil.NopCloser(strings.NewReader("n\nemail\ninvalid\n"))
+	ensure.Err(t, c.accessToken(h.env), regexp.MustCompile("Please try again"))
+	ensure.DeepEqual(t,
+		h.Err.String(),
+		`Sorry, we do not have a user with this email and access token.
+Please follow instructions at https://www.parse.com/account/account_keys to generate a new access token.
+`)
+}

--- a/login.go
+++ b/login.go
@@ -14,6 +14,8 @@ import (
 	"github.com/skratchdot/open-golang/open"
 )
 
+const keysURL = "https://www.parse.com/account/account_keys"
+
 type credentials struct {
 	email    string
 	password string
@@ -230,42 +232,4 @@ Please open %q in the browser to create a new account key.
 			keysURL,
 		)
 	}
-}
-
-const keysURL = "https://www.parse.com/account/keys"
-
-func (l *login) run(e *env) error {
-	fmt.Fprintf(e.Out,
-		`Please enter the email id you used to register with Parse
-and an account key if you already generated it.
-If you do not have an account key or would like to generate a new one,
-please type: "y" to open the browser or "n" to continue: `,
-	)
-	l.helpCreateToken(e)
-
-	var credentials credentials
-	fmt.Fprintf(e.Out, "Email: ")
-	fmt.Fscanf(e.In, "%s\n", &credentials.email)
-	fmt.Fprintf(e.Out, "Account Key: ")
-	fmt.Fscanf(e.In, "%s\n", &credentials.token)
-
-	_, err := (&apps{login: login{credentials: credentials}}).restFetchApps(e)
-	if err != nil {
-		if err == errAuth {
-			fmt.Fprintf(e.Err, `Sorry, we do not have a user with this email and account key.
-Please follow instructions at %s to generate a new account key.
-`,
-				keysURL,
-			)
-		} else {
-			fmt.Fprintf(e.Err, "Unable to validate token with error:\n%s\n", err)
-		}
-		return stackerr.New("Could not store credentials. Please try again.")
-	}
-
-	err = l.storeCredentials(e, &credentials)
-	if err == nil {
-		fmt.Fprintln(e.Out, "Successfully stored credentials.")
-	}
-	return stackerr.Wrap(err)
 }

--- a/login_test.go
+++ b/login_test.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"io/ioutil"
 	"regexp"
 	"strings"
 	"testing"
@@ -123,31 +122,4 @@ machine api.example.org
 	login email
 	password token`,
 	)
-}
-
-func TestLogin(t *testing.T) {
-	t.Parallel()
-
-	h, _ := newAppHarness(t)
-	defer h.Stop()
-
-	l := &login{tokenReader: strings.NewReader("")}
-
-	h.env.In = ioutil.NopCloser(strings.NewReader("n\nemail\ntoken\n"))
-	ensure.Nil(t, l.run(h.env))
-	ensure.DeepEqual(t,
-		h.Out.String(),
-		`Please enter the email id you used to register with Parse
-and an account key if you already generated it.
-If you do not have an account key or would like to generate a new one,
-please type: "y" to open the browser or "n" to continue: Email: Account Key: Successfully stored credentials.
-`)
-
-	h.env.In = ioutil.NopCloser(strings.NewReader("n\nemail\ninvalid\n"))
-	ensure.Err(t, l.run(h.env), regexp.MustCompile("Please try again"))
-	ensure.DeepEqual(t,
-		h.Err.String(),
-		`Sorry, we do not have a user with this email and account key.
-Please follow instructions at https://www.parse.com/account/keys to generate a new account key.
-`)
 }

--- a/main.go
+++ b/main.go
@@ -280,6 +280,7 @@ http://parse.com`,
 	}
 
 	c.AddCommand(newAddCmd(e))
+	c.AddCommand(newConfigureCmd(e))
 	c.AddCommand(newDefaultCmd(e))
 	c.AddCommand(newDeployCmd(e))
 	c.AddCommand(newDevelopCmd(e))


### PR DESCRIPTION
refactor existing code in loginCmd to create a new command 'configure token'
also move tests to an appropriate file.