### PR TITLE
refactor configure token command to not ask for email

### DIFF
--- a/apps.go
+++ b/apps.go
@@ -81,10 +81,10 @@ func getAuthHeaders(credentials *credentials, headers http.Header) http.Header {
 	if headers == nil {
 		headers = make(http.Header)
 	}
-	headers.Add("X-Parse-Email", credentials.email)
 	if credentials.token != "" {
 		headers.Add("X-Parse-Account-Key", credentials.token)
 	} else {
+		headers.Add("X-Parse-Email", credentials.email)
 		headers.Add("X-Parse-Password", credentials.password)
 	}
 	return headers

--- a/apps_test.go
+++ b/apps_test.go
@@ -53,7 +53,7 @@ func newAppHarness(t testing.TB) (*Harness, []*app) {
 		email := r.Header.Get("X-Parse-Email")
 		password := r.Header.Get("X-Parse-Password")
 		token := r.Header.Get("X-Parse-Account-Key")
-		if !((email == "email" && password == "password") || (email == "email" && token == "token")) {
+		if !((email == "email" && password == "password") || (token == "token")) {
 			return &http.Response{
 				StatusCode: http.StatusUnauthorized,
 				Body:       ioutil.NopCloser(strings.NewReader(`{"error": "incorrect credentials"}`)),

--- a/configure_cmd.go
+++ b/configure_cmd.go
@@ -13,8 +13,7 @@ type configureCmd struct {
 
 func (c *configureCmd) accessToken(e *env) error {
 	fmt.Fprintf(e.Out,
-		`Please enter the email id you used to register with Parse
-and an access token if you already generated it.
+		`Please enter an access token if you already generated it.
 If you do not have an access token or would like to generate a new one,
 please type: "y" to open the browser or "n" to continue: `,
 	)
@@ -22,16 +21,14 @@ please type: "y" to open the browser or "n" to continue: `,
 	c.login.helpCreateToken(e)
 
 	var credentials credentials
-	fmt.Fprintf(e.Out, "Email: ")
-	fmt.Fscanf(e.In, "%s\n", &credentials.email)
-	fmt.Fprintf(e.Out, "Account Key: ")
+	fmt.Fprintf(e.Out, "Access Token: ")
 	fmt.Fscanf(e.In, "%s\n", &credentials.token)
 
 	_, err := (&apps{login: login{credentials: credentials}}).restFetchApps(e)
 	if err != nil {
 		if err == errAuth {
 			fmt.Fprintf(e.Err,
-				`Sorry, we do not have a user with this email and access token.
+				`Sorry, the access token you provided is not valid.
 Please follow instructions at %s to generate a new access token.
 `,
 				keysURL,

--- a/configure_cmd_test.go
+++ b/configure_cmd_test.go
@@ -16,21 +16,21 @@ func TestConfigureAcessToken(t *testing.T) {
 	defer h.Stop()
 
 	c := configureCmd{login: login{tokenReader: strings.NewReader("")}}
-	h.env.In = ioutil.NopCloser(strings.NewReader("n\nemail\ntoken\n"))
+	h.env.In = ioutil.NopCloser(strings.NewReader("n\ntoken\n"))
 	ensure.Nil(t, c.accessToken(h.env))
 	ensure.DeepEqual(t,
 		h.Out.String(),
-		`Please enter the email id you used to register with Parse
-and an access token if you already generated it.
+		`Please enter an access token if you already generated it.
 If you do not have an access token or would like to generate a new one,
-please type: "y" to open the browser or "n" to continue: Email: Account Key: Successfully stored credentials.
-`)
-
+please type: "y" to open the browser or "n" to continue: Access Token: Successfully stored credentials.
+`,
+	)
 	h.env.In = ioutil.NopCloser(strings.NewReader("n\nemail\ninvalid\n"))
 	ensure.Err(t, c.accessToken(h.env), regexp.MustCompile("Please try again"))
 	ensure.DeepEqual(t,
 		h.Err.String(),
-		`Sorry, we do not have a user with this email and access token.
+		`Sorry, the access token you provided is not valid.
 Please follow instructions at https://www.parse.com/account_keys to generate a new access token.
-`)
+`,
+	)
 }

--- a/login.go
+++ b/login.go
@@ -99,7 +99,6 @@ func (l *login) getTokenCredentials(e *env) (*credentials, error) {
 		return nil, stackerr.Newf("could not find token for %s", server)
 	}
 	return &credentials{
-		email: machine.Login,
 		token: machine.Password,
 	}, nil
 }
@@ -120,9 +119,8 @@ func (l *login) updatedNetrcContent(
 	}
 	machine := tokens.FindMachine(server)
 	if machine == nil {
-		machine = tokens.NewMachine(server, credentials.email, credentials.token, "")
+		machine = tokens.NewMachine(server, "default", credentials.token, "")
 	} else {
-		machine.UpdateLogin(credentials.email)
 		machine.UpdatePassword(credentials.token)
 	}
 
@@ -169,12 +167,10 @@ func (l *login) authUserWithToken(e *env) error {
 	apps := &apps{login: login{credentials: *tokenCredentials}}
 	_, err = apps.restFetchApps(e)
 	if err == errAuth {
-		fmt.Fprintf(e.Err,
+		fmt.Fprintln(e.Err,
 			`Sorry, you have an invalid token associated with the email: %q.
 To avoid typing the email and password everytime,
-please type "parse login" and provide a valid token for the email.
-`,
-			tokenCredentials.email,
+please type "parse configure token" and provide a valid access token.`,
 		)
 	}
 	if err != nil {

--- a/login_test.go
+++ b/login_test.go
@@ -32,13 +32,12 @@ func TestGetTokenCredentials(t *testing.T) {
 
 	l.tokenReader = strings.NewReader(
 		`machine api.example.com
-			login email
+			login default
 			password token
 		`,
 	)
 	credentials, err := l.getTokenCredentials(h.env)
 	ensure.Nil(t, err)
-	ensure.DeepEqual(t, credentials.email, "email")
 	ensure.DeepEqual(t, credentials.token, "token")
 
 	h.env.Server = "http://api.parse.com"
@@ -76,26 +75,26 @@ func TestUpdatedNetrcContent(t *testing.T) {
 	updated, err := l.updatedNetrcContent(h.env,
 		strings.NewReader(
 			`machine api.example.com
-  login email
+  login default
   password token0
 
 machine  api.example.org
-  login email
+  login default
   password token
 `,
 		),
-		&credentials{email: "email", token: "token"},
+		&credentials{token: "token"},
 	)
 
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t,
 		string(updated),
 		`machine api.example.com
-  login email
+  login default
   password token
 
 machine  api.example.org
-  login email
+  login default
   password token
 `,
 	)
@@ -104,22 +103,22 @@ machine  api.example.org
 	updated, err = l.updatedNetrcContent(h.env,
 		strings.NewReader(
 			`machine api.example.com
-	login email
+	login default
 	password token
 `,
 		),
-		&credentials{email: "email", token: "token"},
+		&credentials{token: "token"},
 	)
 
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t,
 		string(updated),
 		`machine api.example.com
-	login email
+	login default
 	password token
 
 machine api.example.org
-	login email
+	login default
 	password token`,
 	)
 }


### PR DESCRIPTION
configure token command was initially written as a login command, so it asks for email & token.
however, this is against the convention, endpoints should authenticate solely based on the token.