### PR TITLE
check if version is supported

### DIFF
--- a/update_cmd_test.go
+++ b/update_cmd_test.go
@@ -3,10 +3,10 @@ package main
 import (
 	"io/ioutil"
 	"net/http"
-	"strings"
 	"testing"
 
 	"github.com/facebookgo/ensure"
+	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/parse"
 )
 
@@ -17,37 +17,20 @@ func TestLatestVersion(t *testing.T) {
 	defer h.Stop()
 
 	ht := transportFunc(func(r *http.Request) (*http.Response, error) {
-		var result string
-		switch r.URL.String() {
-		case windowsCliDownloadURL:
-			result = "http://parse-cli.aws.com/hash/parse-windows-2.0.2.exe"
-		case unixCliDownloadURL:
-			result = "http://parse-cli.aws.com/hash/parse-linux-2.0.2"
-		case macCliDownloadURL:
-			result = "http://parse-cli.aws.com/hash/parse-osx-2.0.2"
-		}
-		resp := http.Response{
+		ensure.DeepEqual(t, r.URL.Path, "/1/supported")
+		return &http.Response{
 			StatusCode: http.StatusOK,
-			Body:       ioutil.NopCloser(strings.NewReader("Success!")),
-		}
-		if resp.Header == nil {
-			resp.Header = make(http.Header)
-		}
-		resp.Header.Set("Location", result)
-		return &resp, nil
+			Body: ioutil.NopCloser(
+				jsonpipe.Encode(
+					map[string]string{"version": "2.0.2"},
+				),
+			),
+		}, nil
 	})
 	h.env.Client = &Client{client: &parse.Client{Transport: ht}}
 	u := new(updateCmd)
 
-	version, err := u.latestVersion(h.env, unixCliDownloadURL)
+	latestVersion, err := u.latestVersion(h.env)
 	ensure.Nil(t, err)
-	ensure.DeepEqual(t, version, "2.0.2")
-
-	version, err = u.latestVersion(h.env, macCliDownloadURL)
-	ensure.Nil(t, err)
-	ensure.DeepEqual(t, version, "2.0.2")
-
-	version, err = u.latestVersion(h.env, windowsCliDownloadURL)
-	ensure.Nil(t, err)
-	ensure.DeepEqual(t, version, "2.0.2")
+	ensure.DeepEqual(t, latestVersion, "2.0.2")
 }

--- a/utils.go
+++ b/utils.go
@@ -3,6 +3,7 @@ package main
 import (
 	"errors"
 	"fmt"
+	"net/http"
 	"net/url"
 	"regexp"
 	"strconv"
@@ -103,4 +104,22 @@ func getHostFromURL(urlStr string) (string, error) {
 		return "", stackerr.Newf("%s is not a valid url", urlStr)
 	}
 	return server, nil
+}
+
+func checkIfSupported(e *env, version string) (string, error) {
+	v := make(url.Values)
+	v.Set("version", version)
+	req := &http.Request{
+		Method: "GET",
+		URL:    &url.URL{Path: "supported", RawQuery: v.Encode()},
+	}
+
+	var res struct {
+		Warning string `json:"warning"`
+	}
+
+	if _, err := e.Client.Do(req, nil, &res); err != nil {
+		return "", stackerr.Wrap(err)
+	}
+	return res.Warning, nil
 }


### PR DESCRIPTION
1) if a cli version was bad, we'll blacklist it at parse
and such cli's should not be used to execute anything
2) instead of forced update, we now print a message asking to update
everytime a new release is made
3) use git releases to download the new binary
4) also support linux_arm now