### PR TITLE
api of update changed in upstream library. fix it

### DIFF
--- a/ios_symbol_uploader.go
+++ b/ios_symbol_uploader.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"fmt"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -177,7 +178,12 @@ func (i *iosSymbolUploader) symbolConversionTool(baseDir string,
 	if updater == nil {
 		if toUpdate {
 			fmt.Fprintln(e.Out, "Fetching required resources...")
-			err, _ = update.New().Target(toolPath).FromUrl(osxSymbolConverterDownloadURL)
+			var resp *http.Response
+			resp, err = http.Get(osxSymbolConverterDownloadURL)
+			if err == nil {
+				defer resp.Body.Close()
+				err = update.Apply(resp.Body, &update.Options{TargetPath: toolPath})
+			}
 		}
 	} else {
 		err = updater(toolPath, osxSymbolConverterDownloadURL)

--- a/update_cmd.go
+++ b/update_cmd.go
@@ -65,8 +65,14 @@ func (u *updateCmd) updateCLI(e *env) (bool, error) {
 	}
 
 	fmt.Fprintf(e.Out, "Downloading binary from %s.\n", downloadURL)
-	if err, _ := update.New().Target(exec).FromUrl(downloadURL); err != nil {
-		return false, stackerr.Newf("Update failed: %v", err)
+	resp, err := http.Get(downloadURL)
+	if err != nil {
+		return false, stackerr.Newf("Update failed with error: %v", err)
+	}
+	defer resp.Body.Close()
+	err = update.Apply(resp.Body, &update.Options{TargetPath: exec})
+	if err != nil {
+		return false, stackerr.Newf("Update failed with error: %v", err)
 	}
 	fmt.Fprintf(e.Out, "Successfully updated binary at: %s\n", exec)
 	return true, nil


### PR DESCRIPTION
update.New does not exist anymore update code to use the new api of go-update library