### PR TITLE
add multiple email support for account keys

### DIFF
--- a/config.go
+++ b/config.go
@@ -45,6 +45,10 @@ type projectConfig struct {
 	// Currently jssdk version is the only
 	// project level config for Parse type.
 	Parse *parseProjectConfig `json:"parse,omitempty"`
+	// ParserEmail is an email id of the Parse developer.
+	// It is associated with this project.
+	// It is used to fetch appropriate credentials from netrc.
+	ParserEmail string `json:"email,omitempty"`
 }
 
 func getConfigFile(e *env) string {

--- a/config.go
+++ b/config.go
@@ -172,6 +172,7 @@ func storeProjectConfig(e *env, c config) error {
 		}
 		lconf := &legacyConfig{Applications: p.Applications}
 		lconf.Global.ParseVersion = p.projectConfig.Parse.JSSDK
+		lconf.Global.ParserEmail = p.projectConfig.ParserEmail
 		return writeLegacyConfigFile(
 			lconf,
 			filepath.Join(e.Root, legacyConfigFile),

--- a/configure_cmd_test.go
+++ b/configure_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -9,10 +10,10 @@ import (
 	"github.com/facebookgo/ensure"
 )
 
-func TestConfigureAcessToken(t *testing.T) {
+func TestConfigureAccessToken(t *testing.T) {
 	t.Parallel()
 
-	h, _ := newAppHarness(t)
+	h := newTokenHarness(t)
 	defer h.Stop()
 
 	c := configureCmd{login: login{tokenReader: strings.NewReader("")}}
@@ -26,11 +27,38 @@ Input your account key or press enter to generate a new one.
 Account Key: Successfully stored credentials.
 `)
 	h.env.In = ioutil.NopCloser(strings.NewReader("email\ninvalid\n"))
-	ensure.Err(t, c.accountKey(h.env), regexp.MustCompile("Please try again"))
+	ensure.Err(t, c.accountKey(h.env), regexp.MustCompile("is not valid"))
 	ensure.DeepEqual(t,
 		h.Err.String(),
-		`Sorry, the account key you provided is not valid.
-Please follow instructions at https://www.parse.com/account_keys to generate a new account key.
+		"Could not store credentials. Please try again.\n\n",
+	)
+}
+
+func TestParserEmail(t *testing.T) {
+	t.Parallel()
+
+	h := newTokenHarness(t)
+	h.makeEmptyRoot()
+	defer h.Stop()
+
+	var n newCmd
+	ensure.Nil(t, n.createConfigWithContent(filepath.Join(h.env.Root, parseLocal), "{}"))
+	ensure.Nil(t,
+		n.createConfigWithContent(
+			filepath.Join(h.env.Root, parseProject),
+			`{"project_type": 1}`,
+		),
+	)
+
+	var c configureCmd
+	ensure.Nil(t, c.parserEmail(h.env, []string{"email2"}))
+	ensure.DeepEqual(
+		t,
+		h.Out.String(),
+		`Successfully configured email for current project to: "email2"
 `,
 	)
+
+	ensure.Err(t, c.parserEmail(h.env, nil), regexp.MustCompile("Invalid args:"))
+	ensure.Err(t, c.parserEmail(h.env, []string{"a", "b"}), regexp.MustCompile("Invalid args:"))
 }

--- a/legacy_config.go
+++ b/legacy_config.go
@@ -16,6 +16,7 @@ var legacyConfigFile = filepath.Join(configDir, "global.json")
 type legacyConfig struct {
 	Global struct {
 		ParseVersion string `json:"parseVersion,omitempty"`
+		ParserEmail  string `json:"email,omitempty"`
 	} `json:"global,omitempty"`
 	Applications map[string]*parseAppConfig `json:"applications,omitempty"`
 }

--- a/list_cmd.go
+++ b/list_cmd.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"os"
 
 	"github.com/facebookgo/stackerr"
@@ -23,6 +24,7 @@ func (l *listCmd) printListOfApps(e *env) error {
 		return stackerr.Wrap(err)
 	}
 	config.pprintApps(e)
+	fmt.Fprintln(e.Out, "")
 	return nil
 }
 

--- a/login.go
+++ b/login.go
@@ -4,12 +4,17 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/bgentry/go-netrc/netrc"
 	"github.com/bgentry/speakeasy"
+	"github.com/facebookgo/jsonpipe"
 	"github.com/facebookgo/stackerr"
 	"github.com/mitchellh/go-homedir"
 	"github.com/skratchdot/open-golang/open"
@@ -34,8 +39,16 @@ If you do not remember your password, please follow instructions at:
   https://www.parse.com/login
 to reset your password`)
 
-	parseNetrc = filepath.Join(".parse", "netrc")
+	tokenErrMsgf = `Sorry, the account key: %q you provided is not valid.
+Please follow instructions at %q to generate a new one.
+`
+	keyNotFound = regexp.MustCompile("Could not find access key")
+	parseNetrc  = filepath.Join(".parse", "netrc")
 )
+
+func accessKeyNotFound(err error) bool {
+	return keyNotFound.MatchString(err.Error())
+}
 
 func (l *login) populateCreds(e *env) error {
 	if l.credentials.email != "" && l.credentials.password != "" {
@@ -82,7 +95,7 @@ func (l *login) getTokensReader() (io.Reader, error) {
 	return file, nil
 }
 
-func (l *login) getTokenCredentials(e *env) (*credentials, error) {
+func (l *login) getTokenCredentials(e *env, email string) (*credentials, error) {
 	reader, err := l.getTokensReader()
 	if err != nil {
 		return nil, stackerr.Wrap(err)
@@ -91,22 +104,46 @@ func (l *login) getTokenCredentials(e *env) (*credentials, error) {
 	if err != nil {
 		return nil, stackerr.Wrap(err)
 	}
-	server, err := getHostFromURL(e.Server)
+	server, err := getHostFromURL(e.Server, email)
 	if err != nil {
 		return nil, err
 	}
 	machine := tokens.FindMachine(server)
-	if machine == nil {
-		return nil, stackerr.Newf("could not find token for %s", server)
+	if machine != nil {
+		return &credentials{
+			token: machine.Password,
+		}, nil
 	}
-	return &credentials{
-		token: machine.Password,
-	}, nil
+
+	if email == "" {
+		return nil, stackerr.Newf("Could not find access key for %q", server)
+	}
+
+	// check for system default account key for the given server
+	// since we could not find account key for the given account (email)
+	server, err = getHostFromURL(e.Server, "")
+	if err != nil {
+		return nil, err
+	}
+	machine = tokens.FindMachine(server)
+	if machine != nil {
+		return &credentials{
+			token: machine.Password,
+		}, nil
+	}
+	return nil, stackerr.Newf(
+		`Could not find access key for email: %q,
+and default access key not configured for %q
+`,
+		email,
+		e.Server,
+	)
 }
 
 func (l *login) updatedNetrcContent(
 	e *env,
 	content io.Reader,
+	email string,
 	credentials *credentials,
 ) ([]byte, error) {
 	tokens, err := netrc.Parse(content)
@@ -114,7 +151,7 @@ func (l *login) updatedNetrcContent(
 		return nil, stackerr.Wrap(err)
 	}
 
-	server, err := getHostFromURL(e.Server)
+	server, err := getHostFromURL(e.Server, email)
 	if err != nil {
 		return nil, err
 	}
@@ -132,7 +169,7 @@ func (l *login) updatedNetrcContent(
 	return updatedContent, nil
 }
 
-func (l *login) storeCredentials(e *env, credentials *credentials) error {
+func (l *login) storeCredentials(e *env, email string, credentials *credentials) error {
 	if l.tokenReader != nil {
 		// tests should not store credentials
 		return nil
@@ -142,6 +179,7 @@ func (l *login) storeCredentials(e *env, credentials *credentials) error {
 	if err != nil {
 		return stackerr.Wrap(err)
 	}
+
 	location := filepath.Join(homeDir, parseNetrc)
 	if err := os.MkdirAll(filepath.Dir(location), 0755); err != nil {
 		return stackerr.Wrap(err)
@@ -150,51 +188,85 @@ func (l *login) storeCredentials(e *env, credentials *credentials) error {
 	if err != nil {
 		return stackerr.Wrap(err)
 	}
-
-	content, err := l.updatedNetrcContent(e, file, credentials)
+	content, err := l.updatedNetrcContent(e, file, email, credentials)
+	if err != nil {
+		return err
+	}
 
 	file, err = os.OpenFile(location, os.O_WRONLY|os.O_TRUNC, 0600)
 	_, err = file.Write(content)
 	return stackerr.Wrap(err)
 }
 
-func (l *login) authUserWithToken(e *env) error {
-	tokenCredentials, err := l.getTokenCredentials(e)
-
-	if err != nil {
-		return err
+func (l *login) authToken(e *env, token string) (string, error) {
+	req := &http.Request{
+		Method: "POST",
+		URL:    &url.URL{Path: "accountkey"},
+		Body: ioutil.NopCloser(
+			jsonpipe.Encode(
+				map[string]string{
+					"accountKey": token,
+				},
+			),
+		),
 	}
 
-	apps := &apps{login: login{credentials: *tokenCredentials}}
-	_, err = apps.restFetchApps(e)
-	if err == errAuth {
-		fmt.Fprintln(e.Err,
-			`Sorry, the account key you configured is not valid.
-`)
+	res := &struct {
+		Email string `json:"email"`
+	}{}
+	if response, err := e.ParseAPIClient.Do(req, nil, res); err != nil {
+		if response.StatusCode == http.StatusUnauthorized {
+			return "", stackerr.Newf(tokenErrMsgf, last4(token), keysURL)
+		}
+		return "", stackerr.Wrap(err)
 	}
+
+	if e.ParserEmail != "" && res.Email != e.ParserEmail {
+		return "", stackerr.Newf("Account key %q does not belong to %q", last4(token), e.ParserEmail)
+	}
+	return res.Email, nil
+}
+
+func (l *login) authUserWithToken(e *env) (string, error) {
+	tokenCredentials, err := l.getTokenCredentials(e, e.ParserEmail)
 	if err != nil {
-		return stackerr.Wrap(err)
+		if stackerr.HasUnderlying(err, stackerr.MatcherFunc(accessKeyNotFound)) {
+			fmt.Fprintln(e.Err, errorString(e, err))
+		}
+		return "", err
+	}
+
+	email, err := l.authToken(e, tokenCredentials.token)
+	if err != nil {
+		fmt.Fprintf(e.Err, "Account key could not be used.\nError: %s\n\n", errorString(e, err))
+		return "", err
 	}
 
 	l.credentials = *tokenCredentials
-	return nil
+	return email, nil
 }
 
 func (l *login) authUser(e *env) error {
-	if l.authUserWithToken(e) == nil {
+	_, err := l.authUserWithToken(e)
+	if err == nil {
 		return nil
+	}
+
+	// user never created an account key: educate them
+	if stackerr.HasUnderlying(err, stackerr.MatcherFunc(os.IsNotExist)) {
+		fmt.Fprintln(
+			e.Out,
+			`We've changed the way the CLI works.
+To save time logging in, you should create an account key.
+`)
 	}
 
 	apps := &apps{}
 	fmt.Fprintln(
 		e.Out,
-		`
-We’ve changed the way the CLI works.
-To save time logging in, you should create an account key.
+		`Type "parse configure accountkey" to create a new account key.
 
-Type “parse configure accountkey” to create a new account key.
-
-Please log in to Parse using your email and password.`,
+Please login to Parse using your email and password.`,
 	)
 	for i := 0; i < numRetries; i++ {
 		err := l.populateCreds(e)

--- a/login_test.go
+++ b/login_test.go
@@ -1,12 +1,43 @@
 package main
 
 import (
+	"encoding/json"
+	"io/ioutil"
+	"net/http"
 	"regexp"
 	"strings"
 	"testing"
 
 	"github.com/facebookgo/ensure"
+	"github.com/facebookgo/parse"
 )
+
+func newTokenHarness(t testing.TB) *Harness {
+	h := newHarness(t)
+	ht := transportFunc(func(r *http.Request) (*http.Response, error) {
+		ensure.DeepEqual(t, r.URL.Path, "/1/accountkey")
+		ensure.DeepEqual(t, r.Method, "POST")
+
+		key := &struct {
+			AccountKey string `json:"accountKey"`
+		}{}
+		ensure.Nil(t, json.NewDecoder(ioutil.NopCloser(r.Body)).Decode(key))
+
+		if key.AccountKey != "token" {
+			return &http.Response{
+				StatusCode: http.StatusUnauthorized,
+				Body:       ioutil.NopCloser(strings.NewReader(`{"error": "incorrect token"}`)),
+			}, nil
+		}
+
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       ioutil.NopCloser(strings.NewReader(`{"email": "email"}`)),
+		}, nil
+	})
+	h.env.ParseAPIClient = &ParseAPIClient{apiClient: &parse.Client{Transport: ht}}
+	return h
+}
 
 func TestPopulateCreds(t *testing.T) {
 	t.Parallel()
@@ -36,31 +67,56 @@ func TestGetTokenCredentials(t *testing.T) {
 			password token
 		`,
 	)
-	credentials, err := l.getTokenCredentials(h.env)
+	credentials, err := l.getTokenCredentials(h.env, "")
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, credentials.token, "token")
 
 	h.env.Server = "http://api.parse.com"
-	credentials, err = l.getTokenCredentials(h.env)
-	ensure.Err(t, err, regexp.MustCompile("could not find token for"))
+	credentials, err = l.getTokenCredentials(h.env, "")
+	ensure.Err(t, err, keyNotFound)
 }
 
 func TestAuthUserWithToken(t *testing.T) {
 	t.Parallel()
 
-	h, _ := newAppHarness(t)
+	h := newTokenHarness(t)
 	defer h.Stop()
 
 	l := &login{}
+	h.env.ParserEmail = "email"
 	h.env.Server = "http://api.example.org/1/"
 
 	l.tokenReader = strings.NewReader(
-		`machine api.example.org
-			login email
+		`machine api.example.org#email
+			login default
 			password token
 		`,
 	)
-	ensure.Nil(t, l.authUserWithToken(h.env))
+	_, err := l.authUserWithToken(h.env)
+	ensure.Nil(t, err)
+
+	h.env.ParserEmail = "email2"
+
+	l.tokenReader = strings.NewReader(
+		`machine api.example.org#email2
+			login default
+			password token
+		`,
+	)
+	_, err = l.authUserWithToken(h.env)
+	ensure.Err(t, err, regexp.MustCompile(`does not belong to "email2"`))
+
+	h.env.ParserEmail = ""
+
+	l.tokenReader = strings.NewReader(
+		`machine api.example.org
+			login default
+			password token2
+		`,
+	)
+	_, err = l.authUserWithToken(h.env)
+	ensure.Err(t, err, regexp.MustCompile("provided is not valid"))
+
 }
 
 func TestUpdatedNetrcContent(t *testing.T) {
@@ -72,9 +128,10 @@ func TestUpdatedNetrcContent(t *testing.T) {
 	l := &login{}
 
 	h.env.Server = "https://api.example.com/1/"
-	updated, err := l.updatedNetrcContent(h.env,
+	updated, err := l.updatedNetrcContent(
+		h.env,
 		strings.NewReader(
-			`machine api.example.com
+			`machine api.example.com#email
   login default
   password token0
 
@@ -83,13 +140,14 @@ machine  api.example.org
   password token
 `,
 		),
+		"email",
 		&credentials{token: "token"},
 	)
 
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t,
 		string(updated),
-		`machine api.example.com
+		`machine api.example.com#email
   login default
   password token
 
@@ -107,6 +165,7 @@ machine  api.example.org
 	password token
 `,
 		),
+		"email",
 		&credentials{token: "token"},
 	)
 
@@ -117,7 +176,7 @@ machine  api.example.org
 	login default
 	password token
 
-machine api.example.org
+machine api.example.org#email
 	login default
 	password token`,
 	)

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ type env struct {
 	Root           string // project root
 	Server         string // parse api server
 	Type           int    // project type
+	ParserEmail    string // email associated with developer parse account
 	ErrorStack     bool
 	Out            io.Writer
 	Err            io.Writer
@@ -50,14 +51,15 @@ func main() {
 	}()
 
 	e := env{
-		Root:       os.Getenv("PARSE_ROOT"),
-		Server:     os.Getenv("PARSE_SERVER"),
-		ErrorStack: os.Getenv("PARSE_ERROR_STACK") == "1",
-		Out:        os.Stdout,
-		Err:        os.Stderr,
-		In:         os.Stdin,
-		Exit:       os.Exit,
-		Clock:      clock.New(),
+		Root:        os.Getenv("PARSE_ROOT"),
+		Server:      os.Getenv("PARSE_SERVER"),
+		ErrorStack:  os.Getenv("PARSE_ERROR_STACK") == "1",
+		ParserEmail: os.Getenv("PARSER_EMAIL"),
+		Out:         os.Stdout,
+		Err:         os.Stderr,
+		In:          os.Stdin,
+		Exit:        os.Exit,
+		Clock:       clock.New(),
 	}
 	if e.Root == "" {
 		cur, err := os.Getwd()
@@ -74,6 +76,9 @@ func main() {
 				os.Exit(1)
 			}
 			e.Type = config.getProjectConfig().Type
+			if e.ParserEmail == "" {
+				e.ParserEmail = config.getProjectConfig().ParserEmail
+			}
 		} else {
 			e.Type = legacyParseFormat
 			e.Root = getLegacyProjectRoot(&e, cur)
@@ -87,6 +92,7 @@ func main() {
 	if e.Server == "" {
 		e.Server = defaultBaseURL
 	}
+
 	apiClient, err := newParseAPIClient(&e)
 	if err != nil {
 		fmt.Fprintln(e.Err, err)

--- a/new.go
+++ b/new.go
@@ -240,6 +240,15 @@ func (n *newCmd) run(e *env) error {
 	if err := n.configureSample(addCmd, app, nil, e); err != nil {
 		return err
 	}
+	if token := apps.login.credentials.token; token != "" {
+		email, err := apps.login.authToken(e, token)
+		if err != nil {
+			return err
+		}
+		if err := (&configureCmd{}).parserEmail(e, []string{email}); err != nil {
+			return err
+		}
+	}
 
 	fmt.Fprintf(e.Out, n.cloudCodeHelpMessage(e, app))
 	return nil

--- a/utils.go
+++ b/utils.go
@@ -97,7 +97,7 @@ func validateURL(urlStr string) error {
 	return nil
 }
 
-func getHostFromURL(urlStr string) (string, error) {
+func getHostFromURL(urlStr, email string) (string, error) {
 	netURL, err := url.Parse(urlStr)
 	if err != nil {
 		return "", stackerr.Wrap(err)
@@ -105,6 +105,9 @@ func getHostFromURL(urlStr string) (string, error) {
 	server := regexp.MustCompile(`(.*):\d+$`).ReplaceAllString(netURL.Host, "$1")
 	if server == "" {
 		return "", stackerr.Newf("%s is not a valid url", urlStr)
+	}
+	if email != "" {
+		return fmt.Sprintf("%s#%s", server, email), nil
 	}
 	return server, nil
 }
@@ -138,6 +141,14 @@ func checkIfSupported(e *env, version string) (string, error) {
 		return "", nil
 	}
 	return "", nil
+}
+
+func last4(str string) string {
+	l := len(str)
+	if l > 4 {
+		return fmt.Sprintf("%s%s", strings.Repeat("*", l-4), str[l-4:l])
+	}
+	return str
 }
 
 // errorString returns the error string with our without the stack trace

--- a/utils_test.go
+++ b/utils_test.go
@@ -74,17 +74,27 @@ func TestABWithNumbers(t *testing.T) {
 
 func TestGetHostFromURL(t *testing.T) {
 	urlStr := "https://api.parse.com/1/"
-	host, err := getHostFromURL(urlStr)
+	host, err := getHostFromURL(urlStr, "")
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, host, "api.parse.com")
 
+	urlStr = "https://api.parse.com/1/"
+	host, err = getHostFromURL(urlStr, "yolo@earth.com")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, host, "api.parse.com#yolo@earth.com")
+
 	urlStr = "https://api.example.com:8080/1/"
-	host, err = getHostFromURL(urlStr)
+	host, err = getHostFromURL(urlStr, "")
 	ensure.Nil(t, err)
 	ensure.DeepEqual(t, host, "api.example.com")
 
+	urlStr = "https://api.example.com:8080/1/"
+	host, err = getHostFromURL(urlStr, "yolo@earth.com")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, host, "api.example.com#yolo@earth.com")
+
 	urlStr = "api.example.com:8080:90"
-	host, err = getHostFromURL(urlStr)
+	host, err = getHostFromURL(urlStr, "")
 	ensure.Err(t, err, regexp.MustCompile("not a valid url"))
 }
 
@@ -131,4 +141,15 @@ func TestIsSupportedError(t *testing.T) {
 	h.env.ParseAPIClient = &ParseAPIClient{apiClient: &parse.Client{Transport: ht}}
 	_, err := checkIfSupported(h.env, "2.0.2")
 	ensure.Err(t, err, regexp.MustCompile("not supported"))
+}
+
+func TestLastFour(t *testing.T) {
+	t.Parallel()
+
+	ensure.DeepEqual(t, last4(""), "")
+	ensure.DeepEqual(t, last4("a"), "a")
+	ensure.DeepEqual(t, last4("ab"), "ab")
+	ensure.DeepEqual(t, last4("abc"), "abc")
+	ensure.DeepEqual(t, last4("abcd"), "abcd")
+	ensure.DeepEqual(t, last4("abcdefg"), "***defg")
 }


### PR DESCRIPTION
* adds multiple email support for account keys
* user can have one default account key & multiple other account keys, one for each account
* if an email is configured for a project, we'll try to use account key for that account (email), otherwise we try to use the default key
* fixes some messaging around account keys flow for rest of the commands