### PR TITLE
add migrate command to upgrate to preferred config format

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -34,6 +34,7 @@ http://parse.com`,
 	c.AddCommand(newJsSdkCmd(e))
 	c.AddCommand(newListCmd(e))
 	c.AddCommand(newLogsCmd(e))
+	c.AddCommand(newMigrateCmd(e))
 	c.AddCommand(newNewCmd(e))
 	c.AddCommand(newReleasesCmd(e))
 	c.AddCommand(newRollbackCmd(e))

--- a/config.go
+++ b/config.go
@@ -68,8 +68,11 @@ func configFromDir(dir string) (config, error) {
 	}
 	if l != nil { // legacy config format
 		projectConfig := &projectConfig{
-			Type:  legacyParseFormat,
-			Parse: &parseProjectConfig{JSSDK: l.Global.ParseVersion},
+			Type: legacyParseFormat,
+			Parse: &parseProjectConfig{
+				JSSDK: l.Global.ParseVersion,
+			},
+			ParserEmail: l.Global.ParserEmail,
 		}
 		applications := l.Applications
 		if applications == nil {

--- a/migrate_cmd.go
+++ b/migrate_cmd.go
@@ -1,0 +1,80 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/facebookgo/stackerr"
+	"github.com/spf13/cobra"
+)
+
+type migrateCmd struct {
+	retainMaster bool
+}
+
+func (m *migrateCmd) upgradeLegacy(e *env, c config) (*parseConfig, error) {
+	p := c.getProjectConfig()
+	if p.Type != legacyParseFormat {
+		return nil, stackerr.New("Already using the preferred config format.")
+	}
+	p.Type = parseFormat
+	config, ok := (c).(*parseConfig)
+	if !ok {
+		return nil, stackerr.Newf("Unexpected config format: %d", p.Type)
+	}
+	if !m.retainMaster {
+		for _, app := range config.Applications {
+			app.MasterKey = ""
+		}
+	}
+	return config, nil
+}
+
+func (m *migrateCmd) run(e *env) error {
+	c, err := configFromDir(e.Root)
+	if err != nil {
+		return err
+	}
+
+	c, err = m.upgradeLegacy(e, c)
+	if err != nil {
+		return err
+	}
+	localErr := storeConfig(e, c)
+	projectErr := storeProjectConfig(e, c)
+	if localErr == nil && projectErr == nil {
+		legacy := filepath.Join(e.Root, legacyConfigFile)
+		err := os.Remove(legacy)
+		if err != nil {
+			fmt.Fprintf(e.Err, "Could not delete: %q. Please remove this file manually.\n", legacy)
+		}
+	} else {
+		local := filepath.Join(e.Root, parseLocal)
+		err := os.Remove(local)
+		if err != nil {
+			fmt.Fprintf(e.Err, "Failed to clean up: %q. Please remove this file manually.\n", local)
+		}
+		project := filepath.Join(e.Root, parseProject)
+		err = os.Remove(project)
+		if err != nil {
+			fmt.Fprintf(e.Err, "Failed to clean up: %q. Please remove this file manually.\n", project)
+		}
+	}
+	return nil
+}
+
+func newMigrateCmd(e *env) *cobra.Command {
+	var m migrateCmd
+	cmd := &cobra.Command{
+		Use:   "migrate",
+		Short: "Migrate project config format to preferred format",
+		Long: `Use this on projects with legacy config format to migrate
+to the preferred format.
+`,
+		Run: runNoArgs(e, m.run),
+	}
+	cmd.Flags().BoolVarP(&m.retainMaster, "retain", "r", m.retainMaster,
+		"Retain any master keys present in config during migration")
+	return cmd
+}

--- a/migrate_cmd_test.go
+++ b/migrate_cmd_test.go
@@ -1,0 +1,78 @@
+package main
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/facebookgo/ensure"
+)
+
+func TestUpgradeLegacyNoOp(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t)
+	defer h.Stop()
+
+	var m migrateCmd
+	c := &parseConfig{projectConfig: &projectConfig{Type: parseFormat}}
+	_, err := m.upgradeLegacy(h.env, c)
+	ensure.Err(t, err, regexp.MustCompile("Already using the preferred config format."))
+}
+
+func TestUpgradeLegacyRetainMaster(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t)
+	defer h.Stop()
+
+	m := migrateCmd{retainMaster: true}
+	c := &parseConfig{
+		Applications: map[string]*parseAppConfig{
+			"app": {ApplicationID: "a", MasterKey: "m"},
+		},
+		projectConfig: &projectConfig{Type: legacyParseFormat},
+	}
+	config, err := m.upgradeLegacy(h.env, c)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, config.Applications["app"].MasterKey, "m")
+}
+
+func TestUpgradeLegacy(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t)
+	defer h.Stop()
+
+	m := migrateCmd{retainMaster: false}
+	c := &parseConfig{
+		Applications: map[string]*parseAppConfig{
+			"app": {ApplicationID: "a", MasterKey: "m"},
+		},
+		projectConfig: &projectConfig{Type: legacyParseFormat},
+	}
+	config, err := m.upgradeLegacy(h.env, c)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, config.Applications["app"].MasterKey, "")
+}
+
+func TestUpgradeLegacyWithEmail(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t)
+	defer h.Stop()
+
+	m := migrateCmd{retainMaster: false}
+	c := &parseConfig{
+		Applications: map[string]*parseAppConfig{
+			"app": {ApplicationID: "a", MasterKey: "m"},
+		},
+		projectConfig: &projectConfig{
+			Type:        legacyParseFormat,
+			ParserEmail: "test@email.com",
+		},
+	}
+	config, err := m.upgradeLegacy(h.env, c)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, config.Applications["app"].MasterKey, "")
+	ensure.DeepEqual(t, config.getProjectConfig().ParserEmail, "test@email.com")
+}


### PR DESCRIPTION
* command to help migrating to the new config format
* allows for one to retain any master keys already present
  not recommended, but if someone is ok exposing the master key, they can still use this