### PR TITLE
[configure] subcommand to create webhooks

### DIFF
--- a/configure_cmd_test.go
+++ b/configure_cmd_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -148,5 +149,365 @@ func TestProjectType(t *testing.T) {
 	h.env.In = ioutil.NopCloser(strings.NewReader("1\n"))
 	err = c.projectType(h.env, nil)
 	ensure.StringContains(t, h.Out.String(), "Successfully set project type to: parse")
+	ensure.Nil(t, err)
+}
+
+func TestCheckTriggerName(t *testing.T) {
+	t.Parallel()
+
+	c := &configureCmd{}
+
+	ensure.Nil(t, c.checkTriggerName("beforeSave"))
+	ensure.Nil(t, c.checkTriggerName("afterSave"))
+	ensure.Nil(t, c.checkTriggerName("beforeDelete"))
+	ensure.Nil(t, c.checkTriggerName("afterDelete"))
+
+	ensure.Nil(t, c.checkTriggerName("BeforeSAVE"))
+	ensure.Nil(t, c.checkTriggerName("AFTERsave"))
+	ensure.Nil(t, c.checkTriggerName("BeforeDELETE"))
+	ensure.Nil(t, c.checkTriggerName("AFTERdelete"))
+
+	ensure.Err(t, c.checkTriggerName("invalid"), regexp.MustCompile("list of valid trigger names"))
+}
+
+func TestPostOrPutHook(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+	defer h.Stop()
+
+	c := &configureCmd{}
+
+	_, _, err := c.postOrPutHook(h.env, nil, "other")
+	ensure.Err(t, err, regexp.MustCompile("invalid format"))
+
+	_, _, err = c.postOrPutHook(h.env, nil, "post", "1")
+	ensure.Err(t, err, regexp.MustCompile("invalid format"))
+
+	_, _, err = c.postOrPutHook(h.env, nil, "put", "1", "2", "3", "4")
+	ensure.Err(t, err, regexp.MustCompile("invalid format"))
+
+	var hooksOps []*hookOperation
+	_, ops, err := c.postOrPutHook(h.env, hooksOps,
+		"post", "call", "https://api.twilio.com/call")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "POST")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{
+			FunctionName: "call",
+			URL:          "https://api.twilio.com/call",
+		},
+	)
+
+	_, ops, err = c.postOrPutHook(h.env, hooksOps,
+		"put", "call", "https://api.twilio.com/call_1")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{
+			FunctionName: "call",
+			URL:          "https://api.twilio.com/call_1",
+		},
+	)
+
+	_, ops, err = c.postOrPutHook(h.env, hooksOps, "post",
+		"_User", "beforeSave", "https://api.twilio.com/message")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "POST")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].trigger,
+		triggerHook{
+			ClassName:   "_User",
+			TriggerName: "beforeSave",
+			URL:         "https://api.twilio.com/message",
+		},
+	)
+
+	_, ops, err = c.postOrPutHook(h.env, hooksOps, "put",
+		"_User", "beforeSave", "https://api.twilio.com/message_1")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].trigger,
+		triggerHook{
+			ClassName:   "_User",
+			TriggerName: "beforeSave",
+			URL:         "https://api.twilio.com/message_1",
+		},
+	)
+
+	_, ops, err = c.postOrPutHook(h.env, hooksOps, "post",
+		"_User", "invalid", "https://other")
+	ensure.Err(t, err, regexp.MustCompile("invalid trigger"))
+}
+
+func TestDeleteHook(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+	defer h.Stop()
+
+	c := &configureCmd{}
+	_, _, err := c.deleteHook(h.env, nil, "delete")
+	ensure.Err(t, err, regexp.MustCompile("invalid format"))
+
+	_, _, err = c.deleteHook(h.env, nil, "invalid", "1")
+	ensure.Err(t, err, regexp.MustCompile("invalid format"))
+
+	_, _, err = c.deleteHook(h.env, nil, "delete", "1", "2")
+	ensure.Err(t, err, regexp.MustCompile("invalid trigger name"))
+
+	var hooksOps []*hookOperation
+	_, ops, err := c.deleteHook(h.env, hooksOps, "delete", "call")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "DELETE")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{FunctionName: "call"},
+	)
+
+	_, ops, err = c.deleteHook(h.env, hooksOps, "delete", "_User", "beforeSave")
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "DELETE")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].trigger,
+		triggerHook{ClassName: "_User", TriggerName: "beforeSave"},
+	)
+}
+
+func TestAppendHookOperation(t *testing.T) {
+	t.Parallel()
+
+	h := newHarness(t)
+	defer h.Stop()
+
+	c := &configureCmd{}
+
+	var hooksOps []*hookOperation
+	_, ops, err := c.appendHookOperation(h.env, "\n\t	", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, hooksOps, ops)
+
+	_, _, err = c.appendHookOperation(h.env, "invalid", nil)
+	ensure.Err(t, err, regexp.MustCompile("invalid format"))
+
+	_, ops, err = c.appendHookOperation(h.env, "post,call,https://twilio.com/call", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "POST")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{FunctionName: "call", URL: "https://twilio.com/call"},
+	)
+
+	_, ops, err = c.appendHookOperation(h.env, "put,call,https://twilio.com/call_1", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{FunctionName: "call", URL: "https://twilio.com/call_1"},
+	)
+
+	_, ops, err = c.appendHookOperation(h.env, "put,call,https://twilio.com/call_1,call_2", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{FunctionName: "call", URL: "https://twilio.com/call_1,call_2"},
+	)
+
+	//random junk
+	_, ops, err = c.appendHookOperation(h.env,
+		"put,call,https://twilio.com/call_1,call_2,call_3", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].function,
+		functionHook{FunctionName: "call", URL: "https://twilio.com/call_1,call_2,call_3"},
+	)
+
+	_, ops, err = c.appendHookOperation(h.env,
+		"posT,_User,afterDelete,https://twilio.com/message", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "POST")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].trigger,
+		triggerHook{ClassName: "_User", TriggerName: "afterDelete", URL: "https://twilio.com/message"},
+	)
+
+	_, ops, err = c.appendHookOperation(h.env,
+		"pUt,_User,afterDelete,https://twilio.com/message_1", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].trigger,
+		triggerHook{ClassName: "_User", TriggerName: "afterDelete", URL: "https://twilio.com/message_1"},
+	)
+
+	// random junk
+	_, ops, err = c.appendHookOperation(h.env,
+		"pUt,_User,afterDelete,https://twilio.com/message_1,message_2", hooksOps)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, ops[len(ops)-1].method, "PUT")
+	ensure.DeepEqual(
+		t,
+		*ops[len(ops)-1].trigger,
+		triggerHook{ClassName: "_User", TriggerName: "afterDelete", URL: "https://twilio.com/message_1,message_2"},
+	)
+}
+
+func TestCheckStrictMode(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		restOp     string
+		exists     bool
+		strictMode bool
+
+		op      string
+		updated bool
+		err     *regexp.Regexp
+	}{
+		{exists: false, restOp: "put", strictMode: false, op: "POST", updated: true, err: nil},
+		{exists: false, restOp: "post", strictMode: false, op: "POST", updated: false, err: nil},
+		{exists: false, restOp: "delete", strictMode: false, op: "DELETE", updated: true, err: nil},
+		{exists: true, restOp: "put", strictMode: false, op: "PUT", updated: false, err: nil},
+		{exists: true, restOp: "post", strictMode: false, op: "PUT", updated: true, err: nil},
+		{exists: true, restOp: "delete", strictMode: false, op: "DELETE", updated: false, err: nil},
+
+		{exists: false, restOp: "put", strictMode: true, err: regexp.MustCompile("does not exist")},
+		{exists: false, restOp: "post", strictMode: true, op: "POST", updated: false, err: nil},
+		{exists: false, restOp: "delete", strictMode: true, err: regexp.MustCompile("cannot delete")},
+		{exists: true, restOp: "put", strictMode: true, op: "PUT", updated: false, err: nil},
+		{exists: true, restOp: "post", strictMode: true, err: regexp.MustCompile("already exists")},
+		{exists: true, restOp: "delete", strictMode: true, op: "DELETE", updated: false, err: nil},
+	}
+
+	c := &configureCmd{}
+	for _, testCase := range testCases {
+		c.hooksStrict = testCase.strictMode
+		op, updated, err := c.checkStrictMode(testCase.restOp, testCase.exists)
+		if testCase.err == nil {
+			ensure.Nil(t, err)
+			ensure.DeepEqual(t, op, testCase.op)
+			ensure.DeepEqual(t, updated, testCase.updated)
+		} else {
+			ensure.Err(t, err, testCase.err)
+		}
+	}
+}
+
+func TestCreateHookOperations(t *testing.T) {
+	t.Parallel()
+	h := newHarness(t)
+	h.makeEmptyRoot()
+	defer h.Stop()
+
+	hooksConfigFile := filepath.Join(h.env.Root, "webhooks.csv")
+	err := ioutil.WriteFile(
+		hooksConfigFile,
+		[]byte{},
+		0666,
+	)
+	ensure.Nil(t, err)
+
+	c := &configureCmd{}
+
+	f, err := os.Open(hooksConfigFile)
+	ensure.Nil(t, err)
+	ops, err := c.createHooksOperations(h.env, f)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, len(ops), 0)
+	ensure.Nil(t, f.Close())
+
+	err = ioutil.WriteFile(
+		hooksConfigFile,
+		[]byte("\n"),
+		0666,
+	)
+
+	f, err = os.Open(hooksConfigFile)
+	ensure.Nil(t, err)
+	ops, err = c.createHooksOperations(h.env, f)
+	ensure.Nil(t, err)
+	ensure.DeepEqual(t, len(ops), 0)
+	ensure.DeepEqual(t, h.Out.String(), "Ignoring line: 1\n")
+	ensure.Nil(t, f.Close())
+	h.Out.Reset()
+}
+
+func TestFunctionHookExists(t *testing.T) {
+	t.Parallel()
+	h := newFunctionsHarness(t)
+	c := &configureCmd{}
+	exists, err := c.functionHookExists(h.env, "foo")
+	ensure.Nil(t, err)
+	ensure.True(t, exists)
+
+	exists, err = c.functionHookExists(h.env, "bar")
+	ensure.Nil(t, err)
+	ensure.False(t, exists)
+}
+
+func TestDeployFunctionHooks(t *testing.T) {
+	t.Parallel()
+	h := newFunctionsHarness(t)
+	c := &configureCmd{}
+
+	err := c.deployFunctionHook(
+		h.env,
+		&hookOperation{
+			method: "post",
+			function: &functionHook{
+				FunctionName: "foo",
+				URL:          "https://api.example.com/foo",
+			},
+		},
+	)
+	// not an error -> will be converted to put
+	ensure.Nil(t, err)
+}
+
+func TestTriggerHookExists(t *testing.T) {
+	t.Parallel()
+	h := newTriggersHarness(t)
+	c := &configureCmd{}
+	exists, err := c.triggerHookExists(h.env, "foo", "beforeSave")
+	ensure.Nil(t, err)
+	ensure.True(t, exists)
+
+	exists, err = c.triggerHookExists(h.env, "bar", "other")
+	ensure.Nil(t, err)
+	ensure.False(t, exists)
+}
+
+func TestDeployTriggerHooks(t *testing.T) {
+	t.Parallel()
+	h := newTriggersHarness(t)
+	c := &configureCmd{}
+
+	err := c.deployTriggerHook(
+		h.env,
+		&hookOperation{
+			method: "post",
+			trigger: &triggerHook{
+				ClassName:   "foo",
+				TriggerName: "beforeSave",
+				URL:         "https://api.example.com/foo",
+			},
+		},
+	)
+	// not an error -> will be converted to put
 	ensure.Nil(t, err)
 }


### PR DESCRIPTION
* adds a subcommand "hooks" to configure command to create webhooks from a csv config file

* an optional file path can be provided as an argument

```bash
   parse configure hooks [path]
```

* if path is not provided it can read from stdin
- so one can pipe input using piping operator like
```bash
   echo "delete,yolo"|parse configure hooks
   echo -e "delete,yolo\npost,yolo,https://yolo"|pare configure hooks
```
- also you can just type the command and it waits to read from stdin
```bash
  parse configure hooks
  Since a webhooks config file was not provided reading from stdin.

```

* adds a bunch of tests

* in strict mode if deploying  hook fails, the entire operation aborts at that point

* normally, it tries to catch errors for instance, it provides protection against:
 - deleting a non-existant webhook [refrains from performing delete]
 - trying to create an already existing webhook [updates the current webhook with new url]
 - trying to modify a non-existant webhooks [creates it with given url]

NOTE: It is important to note that cloud code deploy & webhook deploy
change a global config object, and these operations are not thread safe.
so changes to webhooks should happen sequentially. using the cli ensure
this very easily, so you do not write your own custom scripts, and then
hit the concurrency issues