### PR TITLE
Command line quotes for Windows

### DIFF
--- a/new.go
+++ b/new.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"strconv"
 
 	"github.com/ParsePlatform/parse-cli/herokucmd"
 	"github.com/ParsePlatform/parse-cli/parsecli"
@@ -35,12 +36,12 @@ func (n *newCmd) curlCommand(e *parsecli.Env, app *parsecli.App) string {
  -H "X-Parse-Application-Id: %s" \
  -H "X-Parse-REST-API-Key: %s" \
  -H "Content-Type: application/json" \
- -d '%s' \
+ -d %s \
  https://api.parse.com/1/functions/hello
 `,
 		app.ApplicationID,
 		app.RestKey,
-		args,
+		strconv.Quote(args),
 	)
 }
 

--- a/new_test.go
+++ b/new_test.go
@@ -147,7 +147,7 @@ func TestCurlCommand(t *testing.T) {
  -H "X-Parse-Application-Id: AppID" \
  -H "X-Parse-REST-API-Key: RestKey" \
  -H "Content-Type: application/json" \
- -d '{}' \
+ -d "{}" \
  https://api.parse.com/1/functions/hello
 `)
 }


### PR DESCRIPTION
The single quote was not working on Windows.  

Converting single quotes to double quotes and adding escape characters for embedded double quotes.